### PR TITLE
chore: fix typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -306,4 +306,7 @@ declare namespace commander {
 }
 
 declare const commander: commander.CommanderStatic;
-export = commander;
+
+declare module "@gemini-testing/commander" {
+  export = commander;
+}


### PR DESCRIPTION
- for ability to require typings through `/// <reference types='@gemini-testing/commander' />` - https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html